### PR TITLE
Don't put this package into the base-devel group

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -79,7 +79,6 @@ pkgbase = systemd-git
 pkgname = systemd-git
 	pkgdesc = system and service manager (git version)
 	install = systemd.install
-	groups = base-devel
 	license = GPL2
 	license = LGPL2.1
 	depends = acl

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -119,7 +119,6 @@ build() {
 package_systemd-git() {
   pkgdesc="system and service manager (git version)"
   license=('GPL2' 'LGPL2.1')
-  groups=('base-devel')
   depends=('acl' 'bash' 'cryptsetup' 'dbus' 'iptables' 'kbd' 'kmod' 'hwids' 'libcap'
            'libgcrypt' 'libsystemd' 'libidn2' 'lz4' 'pam' 'libelf' 'libseccomp'
            'util-linux' 'xz' 'pcre2' 'audit')


### PR DESCRIPTION
## Motivation

The Arch Linux Chinese community ([archlinuxcn](https://github.com/archlinuxcn/repo/commits)) maintains binary systemd-git packages in [their unofficial Arch repo](http://repo.archlinuxcn.org/x86_64/). When this repo is in `/etc/pacman.conf`, running `pacman -S base-devel` installs `systemd-git` instead of `core/systemd`:
```
:: There are 27 members in group base-devel:
:: Repository core
   1) autoconf  2) automake  3) binutils  4) bison  5) fakeroot  6) file  7) findutils  8) flex  9) gawk  10) gcc  11) gettext
   12) grep  13) groff  14) gzip  15) libtool  16) m4  17) make  18) pacman  19) patch  20) pkgconf  21) sed  22) sudo
   23) systemd  24) texinfo  25) util-linux  26) which
:: Repository archlinuxcn
   27) systemd-git

Enter a selection (default=all):
resolving dependencies...
looking for conflicting packages...
warning: removing 'systemd' from target list because it conflicts with 'systemd-git'
```
The most common case for such a scenario is building packages for the [archlinuxcn] repo with `archlinuxcn-x86_64-build`, a command from [devtools-cn](https://github.com/yuyichao/devtools-cn) (an extension of [devtools](https://www.archlinux.org/packages/extra/any/devtools/) for the Arch Linux Chinese community). This is not a desired result for some reasons:

* It will be harder to make sure that packages in [archlinuxcn] are reproducible. To ensure reproducibility, packages from the first build should be used. That means every systemd-git updates should be kept, and the current practice in [archlinuxcn] is that only three most recent versions are kept for VCS packages.
* It increases uncertainty. New issues in systemd-git may affect package building.

As a result, I propose to remove this package from the base-devel group.